### PR TITLE
fix получения модуля в Invoice::generateUniqid()

### DIFF
--- a/models/Invoice.php
+++ b/models/Invoice.php
@@ -65,7 +65,7 @@ class Invoice extends ActiveRecord
             $this->id = Yii::$app->db->createCommand($sql)->queryScalar() + 1;
         }
         $id = $this->id . '-' . time();
-        $module = Module::getInstance();
+        $module = Yii::$app->getModule('sberbank');
         if ($module && is_callable($module->idGenerator)) {
             $id = call_user_func($module->idGenerator, $this, $id);
         }


### PR DESCRIPTION
В issue #7 описал проблему, что в Invoice::generateUniqid() не удается получить экземпляр модуля.
Почему? - не смог разобраться.
Если это глобальная ошибка, а не только у меня, и по другому решить ее не получится, то предлагаю решение: заменить получение экземпляра модуля на получение модуля по идентификатору 'sberbank'.
