### PR TITLE
Отключение проверки SSL для поддержки сертификатов от МинЦифры

### DIFF
--- a/components/Sberbank.php
+++ b/components/Sberbank.php
@@ -122,6 +122,8 @@ class Sberbank extends Component
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($data));
         $out = curl_exec($curl);
         curl_close($curl);


### PR DESCRIPTION
В своих модулях сбербанк решает проблему аналогично https://securepayments.sberbank.ru/wiki/doku.php/certificates:add:cms:opencart